### PR TITLE
Linux用にMonoAPI.csを変更他

### DIFF
--- a/MyShogi/Model/Shogi/EngineDefine/CpuType.cs
+++ b/MyShogi/Model/Shogi/EngineDefine/CpuType.cs
@@ -61,8 +61,8 @@ namespace MyShogi.Model.Shogi.EngineDefine
                 return c;
 
             // 64bit環境でなければ無条件でNO_SSEとして扱う
-            if (!Environment.Is64BitOperatingSystem)
-                c = CpuType.NO_SSE;
+            //if (!Environment.Is64BitOperatingSystem)
+            //    c = CpuType.NO_SSE;
             else
                 // 64bit環境である。
                 // 思考エンジンは別プロセスで動作させるので、このプロセスが32bitであっても問題ない。

--- a/MyShogi/MyShogi.csproj
+++ b/MyShogi/MyShogi.csproj
@@ -281,7 +281,7 @@
     <Compile Include="View\Win2D\Info\EngineConsiderationMainControl.cs">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="View\Win2D\Info\EngineConsiderationMainControl.designer.cs">
+    <Compile Include="View\Win2D\Info\EngineConsiderationMainControl.Designer.cs">
       <DependentUpon>EngineConsiderationMainControl.cs</DependentUpon>
     </Compile>
     <Compile Include="View\Win2D\Info\MessageDialog.cs">

--- a/MyShogi/View/Win2D/Common/FontUtility.cs
+++ b/MyShogi/View/Win2D/Common/FontUtility.cs
@@ -70,11 +70,11 @@ namespace MyShogi.View.Win2D
                 }
                 else if (c is ToolStrip)
                 {
-                    /*
+                    
                     // ToolStripはambient propertyではないので明示的な設定が必要。
                     ToolStrip toolStrip = c as ToolStrip;
                     toolStrip.Font = font;
-                    */
+                    
                     // →　これ、巻き込まないほうがいいか…。そうか…。
                 }
             }


### PR DESCRIPTION
MonoAPI.csの「物理コア数の取得」「CPUの種別を判定」「メモリのサイズ」を
MacとLinuxで使えるように変更。

CpuType.csで32bitでもAPI.GetCurrentCpu()を実行するように変更。

MyShogi.csprojの"View\Win2D\Info\EngineConsiderationMainControl.designer.cs"の
dsignerをDesignerへ変更。

FontUtility.csのコメントアウト部をアンコメント化。