### PR TITLE
 駒のドラッグ及びマウス追随挙動の変更 

### DIFF
--- a/MyShogi/View/Win2D/Game/GameScreenControl/GameScreenControlEventHandler.cs
+++ b/MyShogi/View/Win2D/Game/GameScreenControl/GameScreenControlEventHandler.cs
@@ -36,10 +36,13 @@ namespace MyShogi.View.Win2D
         {
             if (e.Button == MouseButtons.Left)
             {
+                TheApp.app.Config.EnableMouseDrag = 1;
+
                 mouseLastDown = e.Location;
 
                 // この時点でクリックイベントとして扱って良いのでは…。
-                OnClick(e.Location);
+                //OnClick(e.Location);
+                OnDrag(mouseLastDown, e.Location);
             }
             else if (e.Button == MouseButtons.Right)
             {
@@ -60,20 +63,25 @@ namespace MyShogi.View.Win2D
 
             if (e.Button == MouseButtons.Left)
             {
-#if false
+                //#if false
                 // 移動がないので、これはクリックイベントとして扱う
-                if (mouseLastDown == p)
-                    OnClick(p);
-                else
-                    OnDrag(mouseLastDown, p);
-#endif
-
-                if (mouseLastDown != p)
+                //if (mouseLastDown == p)
+                if (p.X < mouseLastDown.X + 5 && p.X > mouseLastDown.X - 5 && p.Y < mouseLastDown.Y + 5 && p.Y > mouseLastDown.Y - 5)
                 {
-                    OnClick(p , true /* dragged */); // 2点クリックされたかのように扱う
+                    TheApp.app.Config.EnableMouseDrag = 0;
+                    OnClick(p, true);
+                }
+                else
+                {
+                    OnDrag(mouseLastDown, p);
+                }
+//#endif
+                //if (mouseLastDown != p)
+                //{
+                    //OnClick(p, true /* dragged */); // 2点クリックされたかのように扱う
                     // ただし、ここに駒を移動できないときに、そこにある駒を掴み直すのはユーザーの意図しない挙動である
                     // 可能性が高いので、それは行わない。
-                }
+                //}
             }
             else if (e.Button == MouseButtons.Right)
             {

--- a/MyShogi/View/Win2D/Game/GameScreenControl/GameScreenControlEventHelper.cs
+++ b/MyShogi/View/Win2D/Game/GameScreenControl/GameScreenControlEventHelper.cs
@@ -1174,7 +1174,7 @@ namespace MyShogi.View.Win2D
 
         // Drag処理、不評。単にD&Dの始点・終点の2点がクリックされたかのように扱うほうが適切であるようだ。
 
-#if false
+//#if false
         /// <summary>
         /// 盤面がドラッグされたときに呼び出されるハンドラ
         /// </summary>
@@ -1204,7 +1204,7 @@ namespace MyShogi.View.Win2D
                 // 通常の移動であるが、これが駒の移動の条件を満たすことを確認しなければならない。
 
                 // p1がクリックされたあとにp2がクリックされたことにしてお茶を濁す
-                OnClick(p1);
+                //OnClick(p1);
                 OnClick(p2);
 
                 // 簡単なhackだが、これでだいたい意図通りの動作になるようだ。
@@ -1213,7 +1213,7 @@ namespace MyShogi.View.Win2D
             // デバッグ用にドラッグされた升の名前を出力する。
             //Console.WriteLine(sq1.Pretty() + '→' + sq2.Pretty());
         }
-#endif
+//#endif
 
         /// <summary>
         /// マウスが移動したときに呼び出されるハンドラ
@@ -1250,12 +1250,12 @@ namespace MyShogi.View.Win2D
                 MouseClientLocation = pt;
                 MouseClientLocationReverse = reverse; // この保存されたときにreverseであったかも併せて保存しておく。
 
-                if (state.state == GameScreenControlViewStateEnum.PiecePickedUp && TheApp.app.Config.PickedMoveDisplayStyle == 1)
+                if (state.state == GameScreenControlViewStateEnum.PiecePickedUp)
                 {
 
-                    // 駒をマウスカーソルに追随させるモードである
-                    // マウスカーソルが移動しているので、このとき再描画が必要になる。
-                    Dirty = true;
+                        // 駒をマウスカーソルに追随させるモードである
+                        // マウスカーソルが移動しているので、このとき再描画が必要になる。
+                        Dirty = true;
                 }
             }
         }

--- a/MyShogi/View/Win2D/Game/GameScreenControl/GameScreenControlOnDraw.cs
+++ b/MyShogi/View/Win2D/Game/GameScreenControl/GameScreenControlOnDraw.cs
@@ -70,7 +70,7 @@ namespace MyShogi.View.Win2D
                     // 移動元の升に適用されるエフェクトを描画する。
                     DrawSprite(dest, SPRITE.PieceMove(PieceMoveEffect.PickedFrom));
 
-                    switch (config.PickedMoveDisplayStyle)
+                    switch (config.EnableMouseDrag)
                     {
                         case 0:
                             // 少し持ち上げた感じで描画する。

--- a/MyShogi/View/Win2D/Game/GameScreenControl/GameScreenControlOnDraw.cs
+++ b/MyShogi/View/Win2D/Game/GameScreenControl/GameScreenControlOnDraw.cs
@@ -70,18 +70,29 @@ namespace MyShogi.View.Win2D
                     // 移動元の升に適用されるエフェクトを描画する。
                     DrawSprite(dest, SPRITE.PieceMove(PieceMoveEffect.PickedFrom));
 
-                    switch (config.EnableMouseDrag)
+                    if (TheApp.app.Config.EnableMouseDrag == 0)
                     {
-                        case 0:
-                            // 少し持ち上げた感じで描画する。
-                            picked_sprite = new SpriteEx(sprite, dest + new Size(-5, -20));
-                            break;
+                        switch (config.PickedMoveDisplayStyle)
 
-                        case 1:
-                            // マウスカーソルに追随させるモードであるから、マウスカーソルの位置に..
-                            picked_sprite = new SpriteEx(sprite, MouseClientLocation
-                                + new Size(-piece_img_size.Width / 2, -piece_img_size.Height / 2));
-                            break;
+                        {
+                            case 0:
+                                // 少し持ち上げた感じで描画する。
+                                picked_sprite = new SpriteEx(sprite, dest + new Size(-5, -20));
+                                break;
+
+                            case 1:
+                                // マウスカーソルに追随させるモードであるから、マウスカーソルの位置に..
+                                picked_sprite = new SpriteEx(sprite, MouseClientLocation
+                                    + new Size(-piece_img_size.Width / 2, -piece_img_size.Height / 2));
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        // マウスカーソルに追随させるモードであるから、マウスカーソルの位置に..
+                        picked_sprite = new SpriteEx(sprite, MouseClientLocation
+                            + new Size(-piece_img_size.Width / 2, -piece_img_size.Height / 2));
+
                     }
                 });
 


### PR DESCRIPTION
「駒をマウスのドラッグでも移動できるようにするか」の設定に係らず、実際のマウス操作の挙動により、
2点(移動の始点、終点)クリックかドラッグ&ドロップかを判定する。

「駒を掴む表現」の設定は、2点クリック時のみ有効とし、ドラッグ&ドロップ時は常にマウス追随とする。